### PR TITLE
Add re.str dependency explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BUILD=ocamlbuild -use-ocamlfind -pkgs opam-client,cohttp.lwt -no-links -cflags -bin-annot
+BUILD=ocamlbuild -use-ocamlfind -pkgs opam-client,cohttp.lwt,re.str -no-links -cflags -bin-annot
 TARGETS=src/opamRTmain.native src/file_server.native
 OPAMRT=OPAMYES=1 OPAMSWITCH= ./opam-rt
 TESTDIR=/tmp/xxx


### PR DESCRIPTION
Since opam-core no longer depends on it (jbuild files no longer include the dependency, so it's not in META either)
